### PR TITLE
Fix seeds planted by villagers not being removed from their inventory

### DIFF
--- a/fabric/src/main/java/me/thonk/croptopia/mixin/FarmerVillagerTaskMixin.java
+++ b/fabric/src/main/java/me/thonk/croptopia/mixin/FarmerVillagerTaskMixin.java
@@ -12,27 +12,38 @@ import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(FarmerVillagerTask.class)
 public class FarmerVillagerTaskMixin {
 
-
     @Shadow @Nullable private BlockPos currentTarget;
+    @Unique boolean planted = false;
 
     @Inject(method = "keepRunning", at = @At(value = "INVOKE_ASSIGN",
             target = "Lnet/minecraft/item/ItemStack;isEmpty()Z", opcode = 0),
             locals = LocalCapture.CAPTURE_FAILEXCEPTION)
     public void running(ServerWorld serverWorld, VillagerEntity villagerEntity, long l, CallbackInfo ci,
                         BlockState blockState, Block block, Block block2,
-                        SimpleInventory inventory, int i, ItemStack itemStack, boolean bl) {
+                        SimpleInventory inventory, int i, ItemStack itemStack) {
         if (itemStack.getItem() instanceof SeedItem) {
             serverWorld.setBlockState(this.currentTarget, ((SeedItem) itemStack.getItem()).getBlock().getDefaultState(), 3);
-            bl = true;
+            planted = true;
+        }
+    }
+
+    @ModifyVariable(method = "keepRunning", at = @At(value = "LOAD", ordinal = 0))
+    public boolean planted(boolean bl) {
+        if (planted) {
+            planted = false;
+            return true;
         }
 
+        return bl;
     }
 }


### PR DESCRIPTION
## Description

Villagers are able to plant croptopia seeds, but the seeds are not removed from their inventory.
When croptopia crops are modified to drop seeds, the villager's inventory will fill up and at some point they are unable to continue farming.

The reason for that is the `FarmerVillagerTaskMixin`, specifically the line `bl = true;` which does not actually do anything, since that only changes the method parameter but not the actual local variable inside the mixin target method.

I added a very simple fix that overrides the `if (bl)` check if a croptopia seed has been planted just before.

## Suggestion

One drawback of this fix is that it is currently possible to make an automatic farm by giving a villager 1 croptopia seed, which they are able to reuse indefinitely. Since croptopia crops by default don't drop seeds, their inventory won't overflow and they can keep working.

With this fix, villagers need to get new seeds, so I would suggest to make croptopia crops drop seeds as well - it would make sense given how the only vanilla "seed crop" (wheat) does drop seeds as well.