### PR TITLE
Fix cinnamon leaves loot table

### DIFF
--- a/common/src/main/resources/data/croptopia/loot_tables/blocks/cinnamon_leaves.json
+++ b/common/src/main/resources/data/croptopia/loot_tables/blocks/cinnamon_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "items": ["minecraft:shears"]
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "items": ["minecraft:shears"]
                 }
               },
               {


### PR DESCRIPTION
Fixes cinnamon leaf blocks dropping leaf block items instead of saplings/sticks referenced in #164