### PR TITLE
Allow planting Croptopia seeds on Farmer's Delight Rich Soil Farmland in Fabric

### DIFF
--- a/fabric/src/main/java/me/thonk/croptopia/blocks/CroptopiaCropBlock.java
+++ b/fabric/src/main/java/me/thonk/croptopia/blocks/CroptopiaCropBlock.java
@@ -62,7 +62,7 @@ public class CroptopiaCropBlock extends CropBlock {
     }
 
     protected boolean canPlantOnTop(BlockState floor, BlockView world, BlockPos pos) {
-        return floor.isOf(Blocks.GRASS_BLOCK) || floor.isOf(Blocks.FARMLAND) || floor.isOf(Blocks.SAND) || floor.isOf(Blocks.RED_SAND);
+        return super.canPlantOnTop(floor, world, pos) || floor.isOf(Blocks.GRASS_BLOCK) || floor.isOf(Blocks.SAND) || floor.isOf(Blocks.RED_SAND);
     }
 
     @Override

--- a/fabric/src/main/java/me/thonk/croptopia/blocks/CroptopiaCropBlock.java
+++ b/fabric/src/main/java/me/thonk/croptopia/blocks/CroptopiaCropBlock.java
@@ -9,6 +9,7 @@ import net.minecraft.block.ShapeContext;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemConvertible;
+import net.minecraft.tag.BlockTags;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -62,7 +63,7 @@ public class CroptopiaCropBlock extends CropBlock {
     }
 
     protected boolean canPlantOnTop(BlockState floor, BlockView world, BlockPos pos) {
-        return super.canPlantOnTop(floor, world, pos) || floor.isOf(Blocks.GRASS_BLOCK) || floor.isOf(Blocks.SAND) || floor.isOf(Blocks.RED_SAND);
+        return super.canPlantOnTop(floor, world, pos) || floor.isIn(BlockTags.DIRT) || floor.isIn(BlockTags.SAND);
     }
 
     @Override

--- a/fabric/src/main/java/me/thonk/croptopia/items/SeedItem.java
+++ b/fabric/src/main/java/me/thonk/croptopia/items/SeedItem.java
@@ -16,6 +16,7 @@ import net.minecraft.text.TranslatableText;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome.Category;
 import org.jetbrains.annotations.Nullable;
@@ -38,7 +39,7 @@ public class SeedItem extends AliasedBlockItem {
         BlockPos hitPos = context.getBlockPos();
         World world = context.getWorld();
         BlockState state = world.getBlockState(hitPos);
-        if (state.isOf(Blocks.FARMLAND)) {
+        if (state.getBlock() instanceof FarmlandBlock && context.getSide() == Direction.UP) {
             return super.useOnBlock(context);
         }
         return ActionResult.FAIL;


### PR DESCRIPTION
This change substitutes a generic test the target block is an instance of FarmlandBlock instead of specifically Blocks.FARMLAND.  That way anything that extends FarmlandBlock can be used as farmland.

I've also fixed a bug(?) where clicking on the side of Farmland allowed placing Croptopia crops on adjacent sand one Y level lower.  The code was not checking which side of the block was clicked.  As far as I can tell this replicates the vanilla Minecraft behavior.

I'm using Fabric so that's what I've changed; I do not know much about Forge but these may be applicable there as well.
