### PR TITLE
Fix: qualify croptopia:guide as a book

### DIFF
--- a/shared/src/main/resources/data/croptopia/patchouli_books/guide/book.json
+++ b/shared/src/main/resources/data/croptopia/patchouli_books/guide/book.json
@@ -2,6 +2,7 @@
   "name": "Croptopia",
   "landing_text": "Recipes & more.",
   "book_texture": "patchouli:textures/gui/book_blue.png",
+  "dont_generate_book": true,
   "custom_book_item": "croptopia:guide",
   "model": "patchouli:book_blue",
   "use_blocky_font": true,

--- a/shared/src/main/resources/data/minecraft/tags/items/lectern_books.json
+++ b/shared/src/main/resources/data/minecraft/tags/items/lectern_books.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "croptopia:guide"
+  ]
+}


### PR DESCRIPTION
closes #334 

## Changes

Made sure that `croptopia:guide` is qualified as a guide book.

- fixed `book.json` (this solves the said issue)
- add tag `minecraft:lectern_books` (not necessary to solve the issue, but for completeness)
